### PR TITLE
Updated freshness tooltip to show as popovers

### DIFF
--- a/ckanext/subakdc/public/output.css
+++ b/ckanext/subakdc/public/output.css
@@ -572,6 +572,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   white-space: nowrap;
 }
 
+.break-normal {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
 .rounded-full {
   border-radius: 9999px;
 }

--- a/ckanext/subakdc/templates/package/snippets/info.html
+++ b/ckanext/subakdc/templates/package/snippets/info.html
@@ -3,11 +3,29 @@
 {% block nums %}
     {% if 'freshness_score' in h %}
     {% set freshness_score = h.freshness_score(pkg) %}
+    {% set freshness_tooltip = '<p class="break-normal">This score represents how recently one or more of the data resources was last updated.</p>
+                                <ul>
+                                    <li>5: &lt; 6 months</li>
+                                    <li>4: &lt; 12 months</li>
+                                    <li>3: &lt; 18months</li>
+                                    <li>2: &lt; 24 months</li>
+                                    <li>1: &gt; 24 months</li>
+                                </ul>' %}
         {% if freshness_score > 0 %}
             <div class="nums">
                 {# TODO replace inline style with w-full tailwind class #}
                 <dl style="width: 100%">
-                    <dt>{{ _('Dataset freshness') }} <i class="fa-question-circle" title="The dataset freshness score is a measure of how recently a dataset resource was updated."></i></dt>
+                    <dt><span class="underline decoration-dashed"
+                           role="button"
+                           tabindex="0"
+                           title="Dataset freshness score" 
+                           data-target="popover" 
+                           data-content="{{ freshness_tooltip }}" 
+                           data-placement="right"
+                           data-html="true"
+                           data-trigger="focus">
+                           {{ _('Dataset freshness') }}</span>
+                    </dt>
                     <dd>{{ freshness_score }}<span class="text-3xl text-gray-400">/5</span></dd>
                 </dl>
             </div>

--- a/ckanext/subakdc/templates/snippets/package_item.html
+++ b/ckanext/subakdc/templates/snippets/package_item.html
@@ -8,8 +8,25 @@
         {% if 'freshness_score' in h %}
         <div class="flex-auto mt-2 text-right">
             {% set freshness_score = h.freshness_score(package) %}
+            {% set freshness_tooltip = '<p class="break-normal">This score represents how recently one or more of the data resources was last updated.</p>
+                                        <ul>
+                                            <li>5: &lt; 6 months</li>
+                                            <li>4: &lt; 12 months</li>
+                                            <li>3: &lt; 18months</li>
+                                            <li>2: &lt; 24 months</li>
+                                            <li>1: &gt; 24 months</li>
+                                        </ul>' %}
             {% if freshness_score > 0 %}
-                <span class="underline decoration-dashed cursor-help" title="The dataset freshness score is a measure of how recently a dataset resource was updated.">Dataset freshness</span>:
+                <span class="underline decoration-dashed"
+                      role="button"
+                      tabindex="0"
+                      title="Dataset freshness score" 
+                      data-target="popover" 
+                      data-content="{{ freshness_tooltip }}" 
+                      data-placement="left"
+                      data-html="true"
+                      data-trigger="focus">
+                    {{ _('Dataset freshness') }}</span>:
                 <span class="font-bold text-3xl">{{ freshness_score }}<span class="text-xl text-gray-400">/5</span></span>
             {% endif %}
         </div>


### PR DESCRIPTION
Freshness tooltips now implement the popover functionality and display a more informative description of the freshness score

## Dataset view
<img width="622" alt="Screenshot 2022-01-14 at 15 58 46" src="https://user-images.githubusercontent.com/617309/149545925-f7a69741-33a8-4aff-b651-bf59dc254acc.png">

## Dataset search view
<img width="714" alt="Screenshot 2022-01-14 at 15 59 06" src="https://user-images.githubusercontent.com/617309/149545934-67873bff-3dda-4480-858b-712e9f0fb12b.png">
